### PR TITLE
The change contains the following:

### DIFF
--- a/src/NHibernate.Extensions.NpgSql/NpgSqlDialect.cs
+++ b/src/NHibernate.Extensions.NpgSql/NpgSqlDialect.cs
@@ -3,13 +3,16 @@ using NpgsqlTypes;
 
 namespace NHibernate.Extensions.NpgSql;
 
-public class NpgSqlDialet : Dialect.PostgreSQL83Dialect {
+public class NpgSqlDialect : Dialect.PostgreSQL83Dialect {
 
     public override string GetTypeName(
         SqlType sqlType
     ) {
         if (sqlType is NpgSqlType npgSqlType) {
             var npgDbType = npgSqlType.NpgDbType;
+            if (npgDbType == NpgsqlDbType.Numeric) {
+                return "numeric";
+            }
             if (npgDbType == NpgsqlDbType.Json) {
                 return "json";
             }


### PR DESCRIPTION
1. A fix for the decimal data type that has a different name in Npgsql, literally, numeric
2. A misprint fix in the NpgSqlDialect class name